### PR TITLE
DE2174 - Min/Total Buttons on Payment Flow are Wrapping on Mobile

### DIFF
--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -20,6 +20,10 @@
 
 .btn-group {
   margin-top: 5px;
+
+  .btn-option {
+    margin-top: 5px;
+  }
   
   > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle),
   > .btn:first-child:not(:last-child):not(.dropdown-toggle) {


### PR DESCRIPTION
Min/total buttons on the payment flow are wrapping on mobile and look “bunched” on desktop.



