### PR TITLE
US5318 pull non-minified version

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent {
     private state: StateManagerService) {
 
     if ( this.iFrameResizerCW === undefined ) {
-      this.iFrameResizerCW = require('iframe-resizer/js/iframeResizer.contentWindow.min.js');
+      this.iFrameResizerCW = require('iframe-resizer/js/iframeResizer.contentWindow.js');
     }
 
   }


### PR DESCRIPTION
Per Chris Talent.... To get the iframe to resize need change to how the payment widget app is pulling in the iframe resizer content window JS file.
The require is pulling in the minified version, but then the Int/Prod uglify step is *re* minifying it and that is causing a runtime error for some reason. When switch that to pull in the non-minified locally and then use the prod level uglification it all works.