### PR TITLE
DE2271 - Fix error message text stacking

### DIFF
--- a/src/app/summary/summary.component.html
+++ b/src/app/summary/summary.component.html
@@ -39,7 +39,7 @@
   </tr>
 </table>
 <div *ngIf="gift.systemException" class="alert alert-danger">
-  <p>Something went wrong, please try again. If the problem persists, contact the administrator at helpdesk@crossroads.net.</p>
+  Something went wrong, please try again. If the problem persists, contact the administrator at helpdesk@crossroads.net.
 </div>
 
 <footer class="page-footer page-footer--pt-1">


### PR DESCRIPTION
This PR removes html paragraph tags that were causing error text to stack in an unreadable way on small screened devices.