### PR TITLE
US5458 - Update Typekit for Inline Giving Prototype

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
   <meta name="msapplication-config" content="//crossroads-media.s3.amazonaws.com/images/favicon/browserconfig.xml">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
-  <script src="https://use.typekit.net/zjp2efd.js"></script>
+  <script src="https://use.typekit.net/ccb3vpa.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
 </head>
 <body class="inline-giving">

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -11,7 +11,8 @@ $cr-white: #FFF;
 $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 
 // To be changed with Typekit tranfer
-$fontface-header: "bebas-neue", sans-serif;
+$fontface-header: "acumin-pro-extra-condensed", sans-serif;
+$fontface-body: "acumin-pro", sans-serif;
 
 // Form Validation Colors
 $success-state: #66C93E !default;

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -1,5 +1,6 @@
 .inline-giving {
   background-color: $bg-color;
+  font-family: $fontface-body;
   font-size: 16px;
 
   .page-header {


### PR DESCRIPTION
Swap out Ample's Typekit script with Crossroad's, add Crossroad's fontfaces to inline giving CSS.

*Fonts have changed for header and body text.* 