### PR TITLE
Feature/us5769 inline giving validation errors

### DIFF
--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
+  <form class="custom-amount" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
 
     <div class="form-group">
       <label class="sr-only" for="custom-amount">Amount (in dollars)</label>

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -159,7 +159,7 @@
 
   .input-group-addon {
     background-color: $input-bg-color;
-    border: 1px solid $input-bg-color;
+    border: 1px solid transparent;
     border-radius: 0;
     font-size: 1.125em;
   }
@@ -168,7 +168,7 @@
     .form-control {
       background-color: $input-bg-color;
       border: none;
-      border: 1px solid $input-bg-color;
+      border: 1px solid transparent;
       border-radius: 0;
       box-shadow: none;
       height: 2em;
@@ -353,17 +353,55 @@
   // Validation styles
 
   form {
+    .form-control {
+      &.ng-dirty,
+      &.ng-touched {
+        &.ng-invalid {
+          border: 1px solid $danger-state-border;
+        }
+      }
+    }
+
+    .form-control {
+      &.ng-dirty,
+      &.ng-touched {
+        &.ng-valid {
+          border: 1px solid $success-state;
+        }
+      }
+    }
+  }
+
+  .custom-amount {
     &.ng-dirty,
     &.ng-touched {
       &.ng-invalid {
-        .form-group {
+        .form-control,
+        .input-group-addon {
           border: 1px solid $danger-state-border;
+        }
+
+        .form-control {
+          border-left: none;
+        }
+
+        .input-group-addon {
+          border-right: none;
         }
       }
 
       &.ng-valid {
-        .form-group {
+        .form-control,
+        .input-group-addon {
           border: 1px solid $success-state;
+        }
+
+        .form-control {
+          border-left: none;
+        }
+
+        .input-group-addon {
+          border-right: none;
         }
       }
     }
@@ -382,17 +420,17 @@
       text-align: center;
 
       p {
-        font-weight: bold;
-        line-height: 5px;
+        line-height: 10px;
         margin-bottom: 9px;
       }
+
       ul {
         list-style: none;
         padding-left: 0;
       }
 
       li {
-        line-height: 5px;
+        line-height: 10px;
         margin-bottom: 9px;
       }
     }

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -157,17 +157,18 @@
     }
   }
 
-  form {
-    .input-group-addon {
-      background-color: $input-bg-color;
-      border: none;
-      border-radius: 0;
-      font-size: 1.125em;
-    }
+  .input-group-addon {
+    background-color: $input-bg-color;
+    border: 1px solid $input-bg-color;
+    border-radius: 0;
+    font-size: 1.125em;
+  }
 
+  form {
     .form-control {
       background-color: $input-bg-color;
       border: none;
+      border: 1px solid $input-bg-color;
       border-radius: 0;
       box-shadow: none;
       height: 2em;
@@ -352,24 +353,19 @@
   // Validation styles
 
   form {
-    &.submitted {
+    &.ng-dirty,
+    &.ng-touched {
       &.ng-invalid {
-        .input-group-addon {
-          background-color: $danger-state-bg;
-          color: $danger-state-text;
+        .form-group {
+          border: 1px solid $danger-state-border;
         }
       }
-    }
-  }
 
-  .ng-touched,
-  .ng-dirty {
-    .ng-valid {
-      border: 1px solid $success-state;
-    }
-
-    .ng-invalid {
-      border: 1px solid $danger-state-border;
+      &.ng-valid {
+        .form-group {
+          border: 1px solid $success-state;
+        }
+      }
     }
   }
 
@@ -381,7 +377,6 @@
       background-color: $danger-state-bg;
       border-color: $danger-state-border;
       color: $danger-state-text;
-      font-weight: 700;
       margin-top: -15px;
       padding: 5px 0;
       text-align: center;


### PR DESCRIPTION
Addressing Brian's comments:

> 1) Error messages should NOT be bold, make them normal font size.
> 2) "$" should not have a red background. The entire field should have a red border, including the $. I want the "$" to appear as part of the input. To accomplish this, I'm Okay with not using the input addon.