### PR TITLE
Feature/us5784 inline payments update amount interface

### DIFF
--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -29,8 +29,8 @@
       <div class="row">
         <div>
           <span class="btn-payment__icon">
-            <i class="fa fa-circle-thin" aria-hidden="true"></i>
-            <i class="fa fa-check-circle" aria-hidden="true"></i>
+            <i class="fa fa-circle-thin fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-check-circle fa-2x" aria-hidden="true"></i>
           </span>
            {{ item.label }}
         </div>

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -23,12 +23,16 @@
   <div *ngIf="gift.type === 'payment'" class="btn-group btn-group--flex">
     <button *ngFor="let item of amountDue"
             type="button"
-            class="btn--payment btn btn-option btn-option--flex-item"
+            class="btn-payment btn btn-option btn-option--flex-item"
             (click)="onSelectAmount($event, item.amount)"
             [ngClass]="{ active: (!customAmount && gift.amount == item.amount) }">
       <div class="row">
         <div>
-          <span class="glyph" aria-hidden="true"></span> {{ item.label }}
+          <span class="btn-payment__icon">
+            <i class="fa fa-circle-thin" aria-hidden="true"></i>
+            <i class="fa fa-check-circle" aria-hidden="true"></i>
+          </span>
+           {{ item.label }}
         </div>
         <div class="payment--lg">
           {{ item.amount | currency: "USD": true }}

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -20,15 +20,21 @@
     </div>
   </div>
 
-  <div *ngIf="gift.type === 'payment'">
-    <div class="btn-group btn-group--flex btn-group--underline">
-      <button *ngFor="let item of amountDue"
-              class="btn btn-option btn-option--flex-item"
-              (click)="onSelectAmount($event, item.amount)"
-              [ngClass]="{ active: (!customAmount && gift.amount == item.amount) }">
-        {{ item.label }}: {{ item.amount | currency: "USD": true }}
-      </button>
-    </div>
+  <div *ngIf="gift.type === 'payment'" class="btn-group btn-group--flex">
+    <button *ngFor="let item of amountDue"
+            type="button"
+            class="btn--payment btn btn-option btn-option--flex-item"
+            (click)="onSelectAmount($event, item.amount)"
+            [ngClass]="{ active: (!customAmount && gift.amount == item.amount) }">
+      <div class="row">
+        <div>
+          <span class="glyph" aria-hidden="true"></span> {{ item.label }}
+        </div>
+        <div class="payment--lg">
+          {{ item.amount | currency: "USD": true }}
+        </div>
+      </div>
+    </button>
   </div>
 
   <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -62,7 +62,7 @@
             <i class="fa fa-circle-thin fa-2x" aria-hidden="true"></i>
             <i class="fa fa-check-circle fa-2x" aria-hidden="true"></i>
           </span>
-           {{ item.label }}
+           {{ item.label }}:
         </div>
         <div class="payment--lg">
           {{ item.amount | currency: "USD": true }}
@@ -70,6 +70,23 @@
       </div>
     </button>
 
+    <!-- onclick, btn highlight (active class), icon change (display changes for each) and input field appears -->
+    <button type="button"
+            class="btn-payment btn btn-option btn-option--flex-item"
+            (click)="onSelectAmount(amountDue.amount)"
+            [ngClass]="{ active: (gift.amount == amountDue.amount) }">
+      <div class="row">
+        <div>
+          <span class="btn-payment__icon">
+            <i class="fa fa-circle-thin fa-2x" aria-hidden="true"></i>
+            <i class="fa fa-check-circle fa-2x" aria-hidden="true"></i>
+          </span>
+           Other Amount...
+        </div>
+      </div>
+    </button>
+
+    <!-- if custom amount button selected (active), show. if input has focus, button remains selected (active) -->
     <div class="custom-input-payment">
       <span class="custom-input-payment__icon"><i class="fa fa-caret-right" aria-hidden="true"></i></span>
 

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -6,7 +6,7 @@
 </div>
 <div *ngIf="gift.errors.length <= 0">
   <div class="page-header page-header--border-btm">
-    <h2>Amount:</h2>
+    <h2>Amount</h2>
   </div>
 
   <div *ngIf="gift.type === 'donation'">
@@ -17,10 +17,40 @@
               [ngClass]="{ active: (!customAmount && gift.amount == amount) }">
         {{ amount | currency: "USD": true }}
       </button>
+
+      <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
+        <div class="form-group">
+          <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
+          <div class="input-group">
+            <span class="input-group-addon">$</span>
+            <input type="text"
+                  class="form-control"
+                  placeholder="Or Enter Amount"
+                  id="custom-amount"
+                  maxlength="9"
+                  formControlName="customAmount"
+                  onlyTheseKeys="[0-9\.]"
+                  [(ngModel)]="customAmount"
+                  (ngModelChange)="onCustomAmount($event)">
+          </div>
+        </div>
+
+        <div *ngIf="gift.type === 'donation'">
+          <div [class.donation-previous-amount]="gift.loginService.isLoggedIn()">
+            <div class="alert alert-warning" *ngIf="previousAmount">
+              You previously made a ${{previousAmount}} donation. Would you like to give that amount again? <a href="#" (click)="applyPreviousAmount()">Yes</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="errors" *ngIf="( !isValid() && submitted )">
+          <div class="alert alert-danger" [innerHTML]="errorMessage"></div>
+        </div>
+      </form>
     </div>
   </div>
 
-  <div *ngIf="gift.type === 'payment'" class="btn-group btn-group--flex">
+  <div *ngIf="gift.type === 'payment'" class="btn-group btn-group--flex btn-group--underline">
     <button *ngFor="let item of amountDue"
             type="button"
             class="btn-payment btn btn-option btn-option--flex-item"
@@ -39,44 +69,37 @@
         </div>
       </div>
     </button>
+
+    <div class="custom-input-payment">
+      <span class="custom-input-payment__icon"><i class="fa fa-caret-right" aria-hidden="true"></i></span>
+
+      <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
+        <div class="form-group">
+          <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
+          <div class="input-group">
+            <span class="input-group-addon">$</span>
+            <input type="text"
+                  class="form-control"
+                  placeholder="Enter Amount"
+                  id="custom-amount"
+                  maxlength="9"
+                  formControlName="customAmount"
+                  onlyTheseKeys="[0-9\.]"
+                  [(ngModel)]="customAmount"
+                  (ngModelChange)="onCustomAmount($event)">
+          </div>
+        </div>
+
+        <div class="errors" *ngIf="( !isValid() && submitted )">
+          <div class="alert alert-danger" [innerHTML]="errorMessage"></div>
+        </div>
+      </form>
+    </div>
   </div>
 
-  <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
-
-    <div class="form-group">
-      <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
-      <div class="input-group">
-        <span class="input-group-addon">$</span>
-        <input type="text"
-               class="form-control"
-               placeholder="Or Enter Amount"
-               id="custom-amount"
-               maxlength="9"
-               formControlName="customAmount"
-               onlyTheseKeys="[0-9\.]"
-               [(ngModel)]="customAmount"
-               (ngModelChange)="onCustomAmount($event)">
-      </div>
-    </div>
-
-    <div *ngIf="gift.type === 'donation'">
-      <div [class.donation-previous-amount]="gift.loginService.isLoggedIn()">
-        <div class="alert alert-warning" *ngIf="previousAmount">
-          You previously made a ${{previousAmount}} donation. Would you like to give that amount again? <a href="#" (click)="applyPreviousAmount()">Yes</a>
-        </div>
-      </div>
-    </div>
-
-
-    <div class="errors" *ngIf="( !isValid() && submitted )">
-      <div class="alert alert-danger" [innerHTML]="errorMessage"></div>
-    </div>
-
-    <footer class="page-footer">
-      <input type="button" class="btn btn-next btn-block" (click)="next()" value="Next">
-    </footer>
-
-  </form>
+  <footer class="page-footer">
+    <input type="button" class="btn btn-next btn-block" (click)="next()" value="Next">
+  </footer>
 </div>
 
 

--- a/src/app/payment/payment.component.ts
+++ b/src/app/payment/payment.component.ts
@@ -42,15 +42,12 @@ export class PaymentComponent implements OnInit {
 
     this.amountDue = [
       {
-        label: 'Minimum Payment:',
+        label: 'Minimum Payment',
         amount: this.gift.minPayment
       },
       {
-        label: 'Full Balance:',
+        label: 'Full Balance',
         amount: this.gift.totalCost
-      },
-      {
-        label: 'Other Amount...'
       }
     ];
 

--- a/src/app/payment/payment.component.ts
+++ b/src/app/payment/payment.component.ts
@@ -42,12 +42,15 @@ export class PaymentComponent implements OnInit {
 
     this.amountDue = [
       {
-        label: 'Minimum Due',
+        label: 'Minimum Due:',
         amount: this.gift.minPayment
       },
       {
-        label: 'Total Due',
+        label: 'Total Due:',
         amount: this.gift.totalCost
+      },
+      {
+        label: 'Custom Amount...'
       }
     ];
 

--- a/src/app/payment/payment.component.ts
+++ b/src/app/payment/payment.component.ts
@@ -42,15 +42,15 @@ export class PaymentComponent implements OnInit {
 
     this.amountDue = [
       {
-        label: 'Minimum Due:',
+        label: 'Minimum Payment:',
         amount: this.gift.minPayment
       },
       {
-        label: 'Total Due:',
+        label: 'Full Balance:',
         amount: this.gift.totalCost
       },
       {
-        label: 'Custom Amount...'
+        label: 'Other Amount...'
       }
     ];
 

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
   <script src="https://use.typekit.net/zjp2efd.js"></script>
+  <script src="https://use.fontawesome.com/ccd1aba2f7.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
 </head>
 <body class="inline-giving">

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -127,7 +127,7 @@
 
       &__icon {
         .fa {
-          font-size: 1.43em; // 20px
+          /*font-size: 1.43em; // 20px*/
           padding-right: 8px;
           vertical-align: middle;
 

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -82,6 +82,8 @@
     }
 
     .btn-payment {
+      text-align: left;
+
       &.active {
         background-color: $secondary-color;
 
@@ -111,17 +113,18 @@
           @include make-xs-column(6);
 
           &:first-child {
-            text-align: left;
+            /*text-align: left;*/
           }
 
           &:last-child {
-            text-align: right;
+            /*text-align: right;*/
           }
         }
 
         .payment--lg {
           font-size: 24px;
           line-height: 24px;
+          text-align: right;
         }
       }
 

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -127,7 +127,6 @@
 
       &__icon {
         .fa {
-          /*font-size: 1.43em; // 20px*/
           padding-right: 8px;
           vertical-align: middle;
 
@@ -166,10 +165,6 @@
       flex-basis: 30px;
       font-size: 22px;
       padding: 5px 20px 0;
-    }
-
-    .form-group {
-      /*margin-bottom: 0;*/
     }
   }
 

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -73,11 +73,6 @@
         &:not(:last-child):not(.dropdown-toggle) {
           margin-right: 0;
           margin-bottom: .5em;
-
-          @media (min-width: $screen-xs) {
-            margin-right: .5em;
-            margin-bottom: 0;
-          }
         }
       }
     }
@@ -86,14 +81,45 @@
       background-color: $secondary-color;
     }
 
+    .btn--payment {
+      .active {
+        background-color: $secondary-color;
+      }
+
+      .row {
+        border-radius: 4px;
+        margin-top: -9px;
+        margin-bottom: -9px;
+        padding: 20px 0;
+
+        &:hover {
+          background-color: $secondary-color;
+          color: $cr-white;
+        }
+
+        & > div {
+          @include make-xs-column(6);
+
+          &:first-child {
+            text-align: left;
+          }
+
+          &:last-child {
+            text-align: right;
+          }
+        }
+
+        .payment--lg {
+          font-size: 24px;
+          line-height: 18px;
+        }
+      }
+    }
+
     &--flex {
       display: flex;
       flex-flow: column nowrap;
       justify-content: space-between;
-
-      @media (min-width: $screen-xs) {
-        flex-direction: row;
-      }
     }
 
     &--underline {

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -81,9 +81,19 @@
       background-color: $secondary-color;
     }
 
-    .btn--payment {
-      .active {
+    .btn-payment {
+      &.active {
         background-color: $secondary-color;
+
+        .btn-payment__icon {
+          .fa-circle-thin {
+            display: none;
+          }
+
+          .fa-check-circle {
+            display: inline-block;
+          }
+        }
       }
 
       .row {
@@ -112,6 +122,22 @@
         .payment--lg {
           font-size: 24px;
           line-height: 18px;
+        }
+      }
+
+      &__icon {
+        .fa {
+          font-size: 1.43em; // 20px
+          padding-right: 8px;
+          vertical-align: middle;
+
+          &-circle-thin {
+            display: inline-block;
+          }
+
+          &-check-circle {
+            display: none;
+          }
         }
       }
     }

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -100,7 +100,7 @@
         border-radius: 4px;
         margin-top: -9px;
         margin-bottom: -9px;
-        padding: 20px 0;
+        padding: 15px 0;
 
         &:hover {
           background-color: $secondary-color;
@@ -121,7 +121,7 @@
 
         .payment--lg {
           font-size: 24px;
-          line-height: 18px;
+          line-height: 24px;
         }
       }
 
@@ -153,6 +153,23 @@
 
       margin-bottom: 1em;
       padding-bottom: 1em;
+    }
+  }
+
+  .custom-input-payment {
+    align-content: center;
+    display: flex;
+    justify-content: center;
+    margin-bottom: -15px;
+
+    &__icon {
+      flex-basis: 30px;
+      font-size: 22px;
+      padding: 5px 20px 0;
+    }
+
+    .form-group {
+      /*margin-bottom: 0;*/
     }
   }
 

--- a/src/styles/themes/_dark-theme.scss
+++ b/src/styles/themes/_dark-theme.scss
@@ -66,7 +66,7 @@ $dt-page-bg-color: #222222;
       }
     }
 
-    .btn--payment {
+    .btn-payment {
       border-color: $underline-color;
       color: $text-color;
     }

--- a/src/styles/themes/_dark-theme.scss
+++ b/src/styles/themes/_dark-theme.scss
@@ -66,8 +66,14 @@ $dt-page-bg-color: #222222;
       }
     }
 
+    .btn--payment {
+      border-color: $underline-color;
+      color: $text-color;
+    }
+
     .active {
       background-color: $secondary-color;
+      color: $cr-white;
     }
 
     &--underline {


### PR DESCRIPTION
Update initial payments screen to match [updated interface](https://invis.io/XU852E1HJ#/203972465_Inline-Payments-01-Amount-03b).

Given a user processing a payment via the inline payments tool
When I load the payment interface
Then I should see the updated payments interface with single select/radio button option

The functionality should behave similar to how it does today: 
user can only select one option
Selecting Other Amount enables an amount input field 