### PR TITLE
Feature/us5769 inline giving validation errors

### DIFF
--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -72,7 +72,6 @@
         </div>
       </button>
 
-      <!-- onclick, btn highlight (active class), icon change (display changes for each) and input field appears -->
       <button type="button"
               class="btn-payment btn btn-option btn-option--flex-item"
               (click)="selectedCustom()"
@@ -88,7 +87,6 @@
         </div>
       </button>
 
-      <!-- if custom amount button selected (active), show. if input has focus, button remains selected (active) -->
       <div class="custom-input-payment" [@customAmountForm]="customAmtSelected ? 'expanded' : 'collapsed' ">
         <span class="custom-input-payment__icon"><i class="fa fa-caret-right" aria-hidden="true"></i></span>
 

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -92,7 +92,7 @@
       <div class="custom-input-payment" [@customAmountForm]="customAmtSelected ? 'expanded' : 'collapsed' ">
         <span class="custom-input-payment__icon"><i class="fa fa-caret-right" aria-hidden="true"></i></span>
 
-        <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
+        <form class="custom-input-payment__input" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
           <div class="form-group">
             <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
             <div class="input-group">

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -439,7 +439,7 @@
     }
   }
 
-  .custom-amount {
+  .custom-input-payment__input {
     &.ng-touched {
       &.ng-invalid {
         .form-control,

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -423,7 +423,6 @@
 
   form {
     .form-control {
-      &.ng-dirty,
       &.ng-touched {
         &.ng-invalid {
           border: 1px solid $danger-state-border;
@@ -432,7 +431,6 @@
     }
 
     .form-control {
-      &.ng-dirty,
       &.ng-touched {
         &.ng-valid {
           border: 1px solid $success-state;
@@ -442,7 +440,6 @@
   }
 
   .custom-amount {
-    &.ng-dirty,
     &.ng-touched {
       &.ng-invalid {
         .form-control,


### PR DESCRIPTION
Previously, input fields would validate user input as it was entered (represented as a red/green border). Desired functionality is to have input fields validate user input when fields lose focus.

Also fixed style bug where custom amount field didn't properly outline around both the input and connect $ span.