### PR TITLE
Feature/us5769 inline giving style validation errors

### DIFF
--- a/src/app/billing/billing.component.html
+++ b/src/app/billing/billing.component.html
@@ -59,6 +59,15 @@
       </div>
     </div>
 
+    <br>
+
+    <div *ngIf="gift.stripeException" class="alert alert-danger">
+      <p>Your payment method has been declined.</p>
+    </div>
+    <div *ngIf="gift.systemException" class="alert alert-danger">
+      <p>Your payment method has been declined.</p>
+    </div>
+
     <div class="sample-check">
       <small>
         <a (click)="hideCheck = false;" *ngIf="hideCheck">Where can I find this information?</a>
@@ -69,12 +78,6 @@
       </div>
     </div>
 
-    <div *ngIf="gift.stripeException" class="alert alert-danger">
-      <p>Your payment method has been declined.</p>
-    </div>
-    <div *ngIf="gift.systemException" class="alert alert-danger">
-      <p>Your payment method has been declined.</p>
-    </div>    
 
     <footer class="page-footer page-footer--border-top">
       <input type="button" class="btn btn-previous pull-left" (click)="back()" value="Back">
@@ -150,7 +153,7 @@
     </div>
     <div *ngIf="gift.systemException" class="alert alert-danger">
       <p>Your payment method has been declined.</p>
-    </div>    
+    </div>
 
     <footer class="page-footer page-footer--border-top">
       <input type="button" class="btn btn-previous pull-left" (click)="back()" value="Back">

--- a/src/app/billing/billing.component.scss
+++ b/src/app/billing/billing.component.scss
@@ -1,5 +1,6 @@
 .sample-check {
   padding: 1em 0;
+  padding: 0 0 1em;
   a {
     display: block;
     cursor: pointer;

--- a/src/app/payment/payment.component.html
+++ b/src/app/payment/payment.component.html
@@ -19,7 +19,7 @@
       </button>
     </div>
 
-    <form [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
+    <form class="custom-input-payment__input" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="next()">
       <div class="form-group">
         <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
         <div class="input-group">

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -525,7 +525,7 @@
 
       p {
         line-height: 10px;
-        margin-bottom: 9px;
+        margin: 7px 0 10px;
       }
 
       ul {


### PR DESCRIPTION
Modify alert messages per Brian's feedback:

1. On donation & payment screens, the validation border should wrap entire custom input block (including '$')
2. On billing/bank account, the alert message declining payment should be above the sample check
3. The top & bottom spacing of text inside the alert messages should be centered across app