### PR TITLE
US5785 - Inline Giving Design Tweaks

### DIFF
--- a/src/styles/base/_global.scss
+++ b/src/styles/base/_global.scss
@@ -6,8 +6,3 @@ hr,
 tbody > tr > td {
   border-color: #ddd;
 }
-
-*:focus,
-a:focus {
-  outline-color: $cr-light-blue;
-}

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -30,7 +30,7 @@
   &.active {
     &:focus,
     &.focus {
-      outline-color: $cr-light-blue;
+      outline: none;
     }
   }
 


### PR DESCRIPTION
Per Brian's request, removing `:focus` state from buttons if they are also `:active`. User can see a `:focus` of the `$cr-light-blue` outline if using the tab key to navigate through the app.