### PR TITLE
US5984: Give As Guest With Existing Email

### DIFF
--- a/src/app/authentication/authentication.component.html
+++ b/src/app/authentication/authentication.component.html
@@ -87,7 +87,7 @@
 
       <footer class="page-footer">
         <input type="button" class="btn btn-previous pull-left" (click)="back()" value="Back">
-        <input type="button" class="btn btn-next pull-right" (click)="submitGuest()" value="Next">
+        <input type="button" class="btn btn-next pull-right" (click)="submitGuest()" value="{{buttonText}}">
       </footer>
     </form>
   </div>

--- a/src/app/authentication/authentication.component.spec.ts
+++ b/src/app/authentication/authentication.component.spec.ts
@@ -112,6 +112,37 @@ describe('Component: Authentication', () => {
         fixture.submitGuest();
         expect(router.navigateByUrl).toHaveBeenCalled();
       });
+
+      describe('and user with provided email exists and isGuestNotifiedOfExistingAccount is false', () => {
+        it('then isGuestNotifiedOfExistingAccount should get set to true and adv() does not get called', () => {
+          spyOn(fixture, 'adv');
+          expect(fixture.isGuestNotifiedOfExistingAccount).toBe(false);
+          setGuestEmailExists(true);
+          fixture.submitGuest();
+          expect(fixture.isGuestNotifiedOfExistingAccount).toBe(true);
+          expect(fixture.adv).not.toHaveBeenCalled();
+        });
+
+        it('then buttonText should be set to `Continue Anyway`', () => {
+          expect(fixture.buttonText).toBe('Next');
+          setGuestEmailExists(true);
+          fixture.submitGuest();
+          expect(fixture.buttonText).toBe('Continue Anyway');
+        });
+      });
+
+      describe('and account with provided email exists and isGuestNotifiedOfExistingAccount is true', () => {
+        it('then the router allows for navigation forward in the process', () => {
+          spyOn(fixture, 'adv');
+          expect(fixture.isGuestNotifiedOfExistingAccount).toBe(false);
+          setGuestEmailExists(true);
+          fixture.submitGuest();
+          expect(fixture.adv).not.toHaveBeenCalled();
+          expect(fixture.isGuestNotifiedOfExistingAccount).toBe(true);
+          fixture.submitGuest();
+          expect(fixture.adv).toHaveBeenCalled();
+        });
+      });
     });
   });
 

--- a/src/app/authentication/authentication.component.ts
+++ b/src/app/authentication/authentication.component.ts
@@ -16,18 +16,20 @@ import { StateManagerService } from '../services/state-manager.service';
   providers: [CheckGuestEmailService]
 })
 export class AuthenticationComponent implements OnInit {
-  public signinOption: string = 'Sign In';
-
+  buttonText: string = 'Next';
   public email: string;
   public form: FormGroup;
   public formGuest: FormGroup;
   public formGuestSubmitted: boolean;
   public formSubmitted: boolean;
   public guestEmail: boolean;
+  public isGuestNotifiedOfExistingAccount: boolean = false;
   public loginException: boolean;
+  public signinOption: string = 'Sign In';
   public userPmtInfo: any;
-  private helpUrl: string;
+
   private forgotPasswordUrl: string;
+  private helpUrl: string;
 
   constructor( private router: Router,
     private state: StateManagerService,
@@ -91,10 +93,12 @@ export class AuthenticationComponent implements OnInit {
       this.checkGuestEmailService.guestEmailExists(this.email).subscribe(
         resp => {
           this.guestEmail = resp;
-          if ( resp === false ) {
+          if ( this.isGuestNotifiedOfExistingAccount === true || resp === false ) {
             this.gift.email = this.email;
             this.adv();
           } else {
+            this.isGuestNotifiedOfExistingAccount = true;
+            this.buttonText = 'Continue Anyway';
             this.state.setLoading(false);
           }
         }


### PR DESCRIPTION
User must confirm using registered email for give as guest before proceeding.

When a user uses a registered email in the give as guest email field, they will be
given a message that prompts them to sign in. A button also displays that allows
the user to continue anyway.