### PR TITLE
Defect/de2493 paste invalid data into account and routing number

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,7 +34,7 @@ import { CurrencyFormatDirective } from './directives/currency-format.directive'
 import { CvvFormatDirective } from './directives/cvv-format.directive';
 import { ExpiryFormatDirective } from './directives/expiry-format.directive';
 import { OnlyTheseKeysDirective } from './directives/only-these-keys.directive';
-import { SimpleCreditCardFormatDirective } from './directives/simple-credit-card-format.directive';
+import { FormatPaymentNumberDirective } from './directives/format-payment-number.directive';
 
 @NgModule({
   imports: [
@@ -65,7 +65,7 @@ import { SimpleCreditCardFormatDirective } from './directives/simple-credit-card
     OnlyTheseKeysDirective,
     PageNotFoundComponent,
     RegisterComponent,
-    SimpleCreditCardFormatDirective,
+    FormatPaymentNumberDirective,
     SummaryComponent,
   ],
   providers: [

--- a/src/app/billing/billing.component.html
+++ b/src/app/billing/billing.component.html
@@ -58,6 +58,7 @@
           placeholder="Routing Number" 
           formControlName="routingNumber" 
           name="routingNumber" 
+          formatPaymentNumber
           [(ngModel)]="store.routingNumber" 
           numbersOnly 
           pattern="[0-9]*"
@@ -81,6 +82,7 @@
           placeholder="{{accountNumberPlaceholder}}" 
           formControlName="accountNumber" 
           name="accountNumber" 
+          formatPaymentNumber
           [(ngModel)]="store.accountNumber" 
           numbersOnly 
           pattern="\s*[0-9]*\s*"
@@ -139,7 +141,7 @@
                formControlName="ccNumber"
                name="ccNumber"
                [(ngModel)]="store.ccNumber"
-               simpleCcNumber
+               formatPaymentNumber
                onlyTheseKeys="[0-9]"
                autocomplete="cc-number">
       </div>

--- a/src/app/directives/format-payment-number.directive.ts
+++ b/src/app/directives/format-payment-number.directive.ts
@@ -2,10 +2,10 @@ import { Directive, ElementRef, HostListener } from '@angular/core';
 import { KeypressValidation } from '../shared/keypress-validation';
 
 @Directive({
-  selector: '[simpleCcNumber]'
+  selector: '[formatPaymentNumber]'
 })
 
-export class SimpleCreditCardFormatDirective {
+export class FormatPaymentNumberDirective {
 
   public target;
   public position;
@@ -41,7 +41,7 @@ export class SimpleCreditCardFormatDirective {
     let val = KeypressValidation.replaceFullWidthChars(this.target.value);
 
     val = val.substring(0, this.target.selectionStart) + input + val.substring(this.target.selectionEnd);
-    let regex: RegExp = new RegExp('[0-9]');
+    let regex: RegExp = new RegExp('^\\d+$');
     return regex.test(val);
   }
 


### PR DESCRIPTION
This pull request changes the regex in SimpleCcFormatDirective that was being used to determine if valid input was being passed into the credit card account number field from `[0-9]` to `^\\d+$`. The name of the the directive was also changed to FormatPaymentNumberDirective. This allows the directive's use to be understandable whether it is being used for the Credit Card Number input field on the CC payment form or the Routing Number / Account Number input fields on the ACH payment form.