### PR TITLE
US5820 - Update start date UI

### DIFF
--- a/src/app/fund-and-frequency/fund-and-frequency.component.html
+++ b/src/app/fund-and-frequency/fund-and-frequency.component.html
@@ -29,7 +29,7 @@
 </form>
 
 <div *ngIf="store.isRecurringGift()" class="btn-group--underline">
-  <h3 class="btn-form__header">Recurs On:</h3>
+  <h3 class="btn-form__header">Starts On:</h3>
   <form class="form-group">
     <label for="recurring_date" class="sr-only">Set recurring date</label>
     <div class="input-group" (click)="toggleDatePicker(true)">


### PR DESCRIPTION
Fix verbage on fund/frequency page per Brian's request.

> The field label is "Recurs On" but the design is "Starts On". I think "Starts On" is more accurate because it's the single date value in which the recurring gift starts, the recurring gift does not "recur" on that date necessarily. 
https://projects.invisionapp.com/share/XU852E1HJ#/screens/204256598_Inline-Giving-04-Details-03a-Monthly