### PR TITLE
Defect/de2467 thank you page language needs changing

### DIFF
--- a/src/app/confirmation/confirmation.component.html
+++ b/src/app/confirmation/confirmation.component.html
@@ -5,16 +5,16 @@
 
   <p *ngIf="store.isDonation()" class="text-block--lg text-block--thin">
     <span *ngIf="store.isRecurringGift()">
-      Thank you! You're giving {{ store.amount | currency:'USD':true | lowercase }} for {{ store.fund.Name }} every {{ store.frequency.value }} on {{ frequencyCalculation() }}, beginning {{ store.startDate.getTime() | date: 'MM/d/yyyy' }}. Thanks for saying "yes" to this mission.
+      Thank you! You're giving <strong>{{ store.amount | currency:'USD':true | lowercase }}</strong> for <strong>{{ store.fund.Name }}</strong> every <strong>{{ store.frequency.value }}</strong> on <strong>{{ frequencyCalculation() }}</strong>, beginning <strong>{{ store.startDate.getTime() | date: 'MM/d/yyyy' }}</strong>. Thanks for saying "yes" to this mission.
     </span>
     <span *ngIf="!store.isRecurringGift()">
-      You just gave {{ store.amount | currency:'USD':true | lowercase }} for {{ store.fund.Name }}. Way to go!
+      You just gave <strong>{{ store.amount | currency:'USD':true | lowercase }}</strong> for <strong>{{ store.fund.Name }}</strong>. Way to go!
     </span>
   </p>
 
   <p *ngIf="store.isPayment()" class="text-block--lg text-block--thin">
-    Thank you for the {{ store.amount | currency:'USD':true | lowercase }} payment
-    <span *ngIf="store.title"> for {{ store.title }}</span>.
+    Thank you for the <strong>{{ store.amount | currency:'USD':true | lowercase }}</strong> payment
+    <span *ngIf="store.title"> for <strong>{{ store.title }}</strong></span>.
   </p>
 
   <p class="text-block--sm">

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -364,6 +364,10 @@
 
     &--thin {
       font-weight: 100;
+
+      strong {
+        font-weight: 300;
+      }
     }
 
     &--pb-2 {


### PR DESCRIPTION
Updating emphasis on Thank You message per Brian's request:

> I'd rather the variable values be bolded sot it's clear in the statement which values where the users's selections. Users scan they don't read :) You could wrap those in a strong tag but strong tags in the "text-block--thin" may need lighted up a bit so they're not agressively bold. If an non-Ample person works this please check in with Sara/Ample on exact styling. Here is a screenshot (https://www.dropbox.com/s/jkngczo9kvdd9an/Screenshot%202016-12-20%2019.25.32.png?dl=0). In this case, font weight within strong tag is 400.