### PR TITLE
Defect/de2551 payment widget error message styling issue

### DIFF
--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -22,7 +22,7 @@
       </button>
     </div>
 
-    <form class="form--underline custom-input-payment__input" action="/" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
+    <form class="custom-input-payment__input" action="/" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
       <div class="form-group">
         <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
         <div class="input-group background-filled-for-alignment">
@@ -49,8 +49,8 @@
   </div>
 
   <!-- PAYMENT -->
-  <div *ngIf="store.isPayment()">
-    <div class="btn-group btn-group--flex-col btn-group--underline">
+  <div class="payment" *ngIf="store.isPayment()">
+    <div class="btn-group btn-group--flex-col">
       <button *ngFor="let item of amountDue"
               type="button"
               class="btn-payment btn btn-option btn-option--flex-item"
@@ -112,8 +112,9 @@
         <div class="alert alert-danger" [innerHTML]="errorMessage"></div>
       </div>
     </div>
-
   </div>
+
+  <hr>
 
   <footer class="page-footer">
     <input type="button" class="btn btn-next btn-block" (click)="store.preSubmit($event);submitAmount();" value="Next">

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -211,11 +211,14 @@
     align-content: center;
     display:-webkit-flex;
     display:flex;
+    height: 44px;
     justify-content: center;
-    margin-bottom: 15px;
     overflow: hidden;
 
     &__icon {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       flex-basis: 30px;
       font-size: 22px;
       padding: 5px 20px 0;
@@ -223,6 +226,20 @@
 
     &__input {
       flex-basis: calc(100% - 30px);
+    }
+  }
+
+  .payment {
+    .errors {
+      margin-top: 10px;
+
+      .alert {
+        margin-bottom: 0;
+
+        &-danger {
+          margin-top: 0;
+        }
+      }
     }
   }
 

--- a/src/styles/layout/_inline-giving.scss
+++ b/src/styles/layout/_inline-giving.scss
@@ -678,7 +678,7 @@
     }
 
     p {
-      line-height: 10px;
+      line-height: 18px;
       margin: 7px 0 10px;
     }
 


### PR DESCRIPTION
styling issue on the payment widget error message

go to https://embedint.crossroads.net/?type=payment&invoice_id=8&total_cost=59.99&min_payment=10
click next without doing anything else
Error message block is overlapping "Other" Box

![de2551](https://cloud.githubusercontent.com/assets/5159392/21646776/89d9513a-d265-11e6-9ce1-fe3ed22ce286.png)


Also,

Error message line spacing is too close together when line wraps to another line.

