### PR TITLE
US6105 - Correct FOUT on inline giving

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -43,6 +43,18 @@
 
   <script src="https://use.typekit.net/ccb3vpa.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
+
+  <script>
+   WebFontConfig = {
+      typekit: { id: 'ccb3vpa' }
+   };
+
+   (function(d) {
+      var wf = d.createElement('script'), s = d.scripts[0];
+      wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js';
+      s.parentNode.insertBefore(wf, s);
+   })(document);
+</script>
 </head>
 <body class="inline-giving">
   <!-- Google Tag Manager -->

--- a/src/styles/base/_global.scss
+++ b/src/styles/base/_global.scss
@@ -6,3 +6,7 @@ hr,
 tbody > tr > td {
   border-color: #ddd;
 }
+
+.wf-loading {
+  visibility: hidden;
+}


### PR DESCRIPTION
> Given a user loading the inline giving tool
When the tool loads (even from iframe) 
Then the correct fonts should load before the copy displays

Add Webfontloader config to index.html and add CSS to hide visibility of fonts when they haven't loaded yet.