### PR TITLE
DE2774: Persist user choice of program on details page

### DIFF
--- a/src/app/fund-and-frequency/fund-and-frequency.component.spec.ts
+++ b/src/app/fund-and-frequency/fund-and-frequency.component.spec.ts
@@ -40,6 +40,7 @@ describe('Component: FundAndFrequency', () => {
   };
 
   let mockFund: Fund = new Fund(5, 'General Giving', 1, true);
+  let mockFundUserSelected: Fund = new Fund(5, 'Foobar Fund', 1, true);
   let mockOneTimeGiftFund: Fund = new Fund(5, 'General Giving', 1, false);
 
   beforeEach(() => {
@@ -67,6 +68,17 @@ describe('Component: FundAndFrequency', () => {
     });
     this.fixture = TestBed.createComponent(FundAndFrequencyComponent);
     this.component = this.fixture.componentInstance;
+  });
+
+  it ('should retrieve the default fund when a user has not selected a fund', () => {
+    this.component.setFund();
+    expect(this.component.store.fund.Name).toBe('General Giving');
+  });
+
+  it('should not retrieve the default fund if the user has selected a fund', () => {
+    this.component.store.fund = mockFundUserSelected;
+    this.component.setFund();
+    expect(this.component.store.fund.Name).toBe('Foobar Fund');
   });
 
   it('should reset the date to the current date time', () => {

--- a/src/app/fund-and-frequency/fund-and-frequency.component.ts
+++ b/src/app/fund-and-frequency/fund-and-frequency.component.ts
@@ -26,7 +26,6 @@ export class FundAndFrequencyComponent implements OnInit {
 
   public fundIdParam: number;
   public isFundSelectShown: boolean = undefined;
-  public defaultFund: Fund;
   public showDatePicker: boolean = false;
 
   constructor(
@@ -37,7 +36,7 @@ export class FundAndFrequencyComponent implements OnInit {
     private state: StateService,
     private fb: FormBuilder) {
     this.fundIdParam = this.store.fundId;
-    this.defaultFund = this.store.fund = this.api.defaults.fund;
+    this.setFund();
     this.form = this.fb.group({
       fund: [this.store.fund, [<any>Validators.required]],
       frequency: [this.store.frequency, [<any>Validators.required]],
@@ -123,4 +122,9 @@ export class FundAndFrequencyComponent implements OnInit {
     }
   }
 
+  public setFund() {
+    if(this.store.fund === undefined) {
+      this.store.fund = this.api.defaults.fund;
+    }
+  }
 }


### PR DESCRIPTION
When a user selects a program to give to on the details page, moves forward a page, and then moves back to the details page, the user choice is now remembered. Unit tests have been added to cover this scenario.