### PR TITLE
DE2862 - Payment input validation

### DIFF
--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -103,13 +103,16 @@
                     (ngModelChange)="onCustomAmount($event)">
             </div>
 
-            <div class="errors" *ngIf="( !this.form.valid && submitted )">
+            <div class="errors" *ngIf="( !this.form.valid && submitted && customAmtSelected )">
               <div class="error help-block" [innerHTML]="errorMessage"></div>
             </div>
           </div>
         </form>
       </div>
 
+      <div class="errors" *ngIf="( !this.form.valid && submitted && !customAmtSelected )">
+        <div class="error help-block" [innerHTML]="errorMessage"></div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Error message changes location based on whether or not the custom field is selected.

NOTE: The error messages would not show up for me. The `errorMessage` variable was `undefined`. I'm not sure what the issue was, but I believe it's local to me. And I put dummy text in there for a moment to ensure the styles looked OK.