### PR TITLE
DE2897 - Input lg

### DIFF
--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -29,7 +29,7 @@
             <i class="icon svg-usd"></i>
           </span>
           <input type="tel"
-                class="form-control"
+                class="form-control input-lg"
                 placeholder="Or Enter Amount"
                 id="custom-amount"
                 maxlength="9"


### PR DESCRIPTION
> It looks like the way we've overwritten the default bootrap inputs causes "input-lg" class to not work.
The amount field should be larger (to match prod design) in embed once the above issue is resolved.

Corresponds with crdschurch/crds-styleguide#66
Corresponds with crdschurch/crds-styles#59