### PR TITLE
Defect/de2897 input lg

### DIFF
--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -22,7 +22,7 @@
     <hr class="flush-top">
 
     <form class="custom-input-field" action="/" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
-      <div class="form-group form-group-lg">
+      <div class="form-group">
         <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
         <div class="input-group input-group-left">
           <span class="input-group-addon">
@@ -85,7 +85,7 @@
               [formGroup]="form"
               [class.submitted]="submitted"
               (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
-          <div class="form-group form-group-lg">
+          <div class="form-group">
             <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
             <div class="input-group input-group-left">
               <span class="input-group-addon">

--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -22,14 +22,14 @@
     <hr class="flush-top">
 
     <form class="custom-input-field" action="/" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
-      <div class="form-group">
+      <div class="form-group form-group-lg">
         <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
         <div class="input-group input-group-left">
           <span class="input-group-addon">
             <i class="icon svg-usd"></i>
           </span>
           <input type="tel"
-                class="form-control input-lg"
+                class="form-control"
                 placeholder="Or Enter Amount"
                 id="custom-amount"
                 maxlength="9"
@@ -85,7 +85,7 @@
               [formGroup]="form"
               [class.submitted]="submitted"
               (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
-          <div class="form-group">
+          <div class="form-group form-group-lg">
             <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
             <div class="input-group input-group-left">
               <span class="input-group-addon">


### PR DESCRIPTION
Refactored form field styles to use Bootstrap input-height helper classes (`input-lg`, `input-sm`, `form-group-lg`, `form-group-sm`).

Removed helper classes from markup as default inputs match desired design.

Corresponds with:
crdschurch/crds-styleguide#73
crdschurch/crds-styles#66