### PR TITLE
DE3003 - Embed register page has duplicate links

### DIFF
--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -30,10 +30,7 @@
         <input type="text" class="form-control" placeholder="Email" formControlName="email" name="email" [(ngModel)]="email" >
 
       <div class="errors" *ngIf="(submitted) && (!regForm.controls['email'].valid || duplicateUser)">
-        <div class="error help-block" *ngIf="duplicateUser">
-          <span [innerHtml]="store.content.getContent('embedRegisterEmailInUse')"></span>
-          <p><a (click)="back()">Sign In</a> or try <a [href]="forgotPasswordUrl" target="_blank">Forgot password</a>.</p>
-        </div>
+        <p class="error help-block" *ngIf="duplicateUser">This email address is already in use. <a class="pointer" (click)="back()">Sign In</a> or try <a [href]="forgotPasswordUrl" target="_blank">Forgot password</a>.</p>
         <p class="error help-block" *ngIf="!duplicateUser">Email <span [innerHTML]="switchMessage(regForm.controls['email'].errors)"></span></p>
       </div>
       </div>


### PR DESCRIPTION
> If you go to Embed Sign in Page and then Click the register account link, then fill in all fields and enter in an email that is already in registered, the error message that shows under the email field will have 2 links for Sign In and Forgot Password.

Made markup more aligned with the updated Connect code. Behaves as expected:
![embed-duplicate-links](https://cloud.githubusercontent.com/assets/5159392/24011921/8c7f5496-0a52-11e7-9c79-4691749d8b95.gif)


Corresponds with `crds-styles/development`