### PR TITLE
DE3013 - Credit card screen warning message layout

### DIFF
--- a/src/app/billing/billing.component.html
+++ b/src/app/billing/billing.component.html
@@ -120,7 +120,7 @@
 <div *ngIf="store.paymentMethod == 'Credit Card'" heading="Credit Card">
 
   <div>
-    <alert dismissible="true" ><span [innerHtml]="store.content.getContent('embedPleaseUseBank')"></span> </alert>
+    <alert><span [innerHtml]="store.content.getContent('embedPleaseUseBank')"></span></alert>
   </div>
 
   <form [formGroup]="ccForm" action="/" [class.submitted]="ccSubmitted" (ngSubmit)="store.preSubmit($event);ccSubmit();" novalidate>


### PR DESCRIPTION
Remove dismissable option from the warning alert. Not necessary and introduces padding-right error to dismissable blocks.

Corresponds with development branch of crds-styles.