### PR TITLE
DE2988 - Finder component styling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "copy-webpack-plugin": "^4.0.0",
     "css-loader": "^0.25.0",
     "css-to-string-loader": "^0.1.2",
-    "crds-styles": "0.2.0",
+    "crds-styles": "crdschurch/crds-styles#development",
     "dotenv-webpack": "1.3.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",

--- a/src/app/amount/amount.component.html
+++ b/src/app/amount/amount.component.html
@@ -24,7 +24,7 @@
     <form class="custom-input-field" action="/" [formGroup]="form" [class.submitted]="submitted" (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
       <div class="form-group">
         <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
-        <div class="input-group input-group-left">
+        <div class="input-group input-group-block input-group-left">
           <span class="input-group-addon">
             <svg class="icon" viewBox="0 0 256 256">
               <use height="256" width="256" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#usd"></use>
@@ -98,7 +98,7 @@
               (ngSubmit)="store.preSubmit($event);submitAmount();" novalidate>
           <div class="form-group">
             <label class="sr-only" for="custom-amount">Amount (in dollars)</label>
-            <div class="input-group input-group-left">
+            <div class="input-group input-group-block input-group-left">
               <span class="input-group-addon">
                 <svg class="icon" viewBox="0 0 256 256">
                   <use height="256" width="256" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/svgs/icons.svg#usd"></use>

--- a/src/app/fund-and-frequency/fund-and-frequency.component.html
+++ b/src/app/fund-and-frequency/fund-and-frequency.component.html
@@ -34,7 +34,7 @@
   <h3 class="control-label">Starts On:</h3>
   <form class="form-group">
     <label for="recurring_date" class="sr-only">Set recurring date</label>
-    <div class="input-group input-group-right" (click)="toggleDatePicker(true)">
+    <div class="input-group input-group-block input-group-right" (click)="toggleDatePicker(true)">
       <input *ngIf="store.startDate"
         id="recurring_date"
         class="form-control"


### PR DESCRIPTION
Finder styling issue move buttons and elements off screen

Map View
Searchbar reflows
Getting started and my Pin buttons cause scroll bars for screen, Also move offscreen on mobile when rotating screen

I updated the custom input fields (on amount and fund & frequency screens)

Corresponds with defect/DE2988-finder-component-styling-issues of `crds-styles`, `crds-styleguide`, `crds-finder`, `crds-embed`